### PR TITLE
Added loading indicator to profile page

### DIFF
--- a/Xamarin/SSW.Consulting/SSW.Consulting/Constants.cs
+++ b/Xamarin/SSW.Consulting/SSW.Consulting/Constants.cs
@@ -7,7 +7,7 @@ namespace SSW.Consulting
     class Constants
     {
 #if DEBUG
-        public const string ApiBaseUrl = "https://427f2ae2.ngrok.io";// https://sswconsulting-dev.azurewebsites.net";
+        public const string ApiBaseUrl = "https://sswconsulting-dev.azurewebsites.net";
 #elif QA
         public const string ApiBaseUrl = "https://sswconsulting-dev.azurewebsites.net";
 #else

--- a/Xamarin/SSW.Consulting/SSW.Consulting/ViewModels/ProfileViewModel.cs
+++ b/Xamarin/SSW.Consulting/SSW.Consulting/ViewModels/ProfileViewModel.cs
@@ -27,12 +27,16 @@ namespace SSW.Consulting.ViewModels
 
         public ProfileViewModel(IUserService userService)
         {
+            IsLoading = true;
+            RaisePropertyChanged("IsLoading");
             _userService = userService;
             _ = Initialise(true);
         }
 
         public ProfileViewModel(LeaderSummaryViewModel vm)
         {
+            IsLoading = true;
+            RaisePropertyChanged("IsLoading");
             ProfilePic = vm.ProfilePic;
             Name = vm.Name;
             Email = vm.Title;
@@ -45,9 +49,6 @@ namespace SSW.Consulting.ViewModels
         {
             IEnumerable<Reward> rewardList = new List<Reward>();
             IEnumerable<Achievement> achievementList = new List<Achievement>();
-
-            IsLoading = true;
-            RaisePropertyChanged("ISLoading");
 
             if(me)
             {

--- a/Xamarin/SSW.Consulting/SSW.Consulting/ViewModels/ProfileViewModel.cs
+++ b/Xamarin/SSW.Consulting/SSW.Consulting/ViewModels/ProfileViewModel.cs
@@ -19,6 +19,8 @@ namespace SSW.Consulting.ViewModels
 
         private int userId { get; set; }
 
+        public bool IsLoading { get; set; }
+
         public ObservableCollection<Reward> Rewards { get; set; }
         public ObservableCollection<Achievement> CompletedAchievements { get; set; }
         public ObservableCollection<Achievement> OutstandingAchievements { get; set; }
@@ -43,6 +45,9 @@ namespace SSW.Consulting.ViewModels
         {
             IEnumerable<Reward> rewardList = new List<Reward>();
             IEnumerable<Achievement> achievementList = new List<Achievement>();
+
+            IsLoading = true;
+            RaisePropertyChanged("ISLoading");
 
             if(me)
             {
@@ -94,7 +99,9 @@ namespace SSW.Consulting.ViewModels
                 }
             }
 
-            RaisePropertyChanged("Rewards", "CompletedAchievements", "OutstandingAchievements");
+            IsLoading = false;
+
+            RaisePropertyChanged("IsLoading", "Rewards", "CompletedAchievements", "OutstandingAchievements");
         }
     }
 }

--- a/Xamarin/SSW.Consulting/SSW.Consulting/Views/Profile.xaml
+++ b/Xamarin/SSW.Consulting/SSW.Consulting/Views/Profile.xaml
@@ -100,6 +100,11 @@
                                        TextColor="White"
                                        FontSize="Body"/>
                             </StackLayout>
+
+                            <ActivityIndicator IsVisible="{Binding IsLoading}"
+                                               IsEnabled="{Binding IsLoading}"
+                                               IsRunning="{Binding IsLoading}"/>
+
                             <controls:RepeaterView ItemsSource="{Binding Rewards}">
                                 <controls:RepeaterView.ItemTemplate>
                                     <DataTemplate>


### PR DESCRIPTION
In PR#72 we changed the profile from using ListView to a custom control called RepeaterView. This removed a bunch of hacky code - using rows as headers and magic string property values to denote to the UI that certain rows were header rows - but doesn't have the nice waterfall list loading effect.

This is an interim improvement and adds an activity indicator while the RepeaterView is loading data. Longer term a nicer loading effect (possibly a skeleton screen with a shimmer effect) can be used.