### PR TITLE
fix profile pic url - empty string creates invalid Uri in Leaderboard

### DIFF
--- a/API/SSW.Rewards/Services/CurrentUserService.cs
+++ b/API/SSW.Rewards/Services/CurrentUserService.cs
@@ -58,7 +58,7 @@ namespace SSW.Rewards.WebAPI.Services
         public string GetUserProfilePic()
         {
 			// TODO: Get the user profile pic from claims
-			return "";
+			return null;
         }
     }
 }


### PR DESCRIPTION
fix profile pic url - empty string creates invalid Uri in Leaderboard AutoMapper