### PR TITLE
Update MSAL packages and revert ApiBaseUrl

### DIFF
--- a/Xamarin/SSW.Rewards/SSW.Rewards.Android/MainActivity.cs
+++ b/Xamarin/SSW.Rewards/SSW.Rewards.Android/MainActivity.cs
@@ -22,7 +22,7 @@ namespace SSW.Rewards.Droid
 
             CrossCurrentActivity.Current.Init(this, savedInstanceState);
             ZXing.Net.Mobile.Forms.Android.Platform.Init();
-            Rg.Plugins.Popup.Popup.Init(this, savedInstanceState);
+            Rg.Plugins.Popup.Popup.Init(this);
 
             global::Xamarin.Forms.Forms.SetFlags("Shell_Experimental", "Visual_Experimental", "CollectionView_Experimental", "FastRenderers_Experimental", "Brush_Experimental");
             Xamarin.Essentials.Platform.Init(this, savedInstanceState);

--- a/Xamarin/SSW.Rewards/SSW.Rewards.Android/SSW.Rewards.Android.csproj
+++ b/Xamarin/SSW.Rewards/SSW.Rewards.Android/SSW.Rewards.Android.csproj
@@ -38,7 +38,6 @@
     <BundleAssemblies>false</BundleAssemblies>
     <AndroidSupportedAbis>armeabi-v7a;x86;x86_64;arm64-v8a</AndroidSupportedAbis>
     <MandroidI18n />
-    <AndroidLinkMode>None</AndroidLinkMode>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -57,7 +56,7 @@
     <DefineConstants>DEBUG;</DefineConstants>
     <DebugType>portable</DebugType>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <MandroidI18n />
@@ -93,7 +92,7 @@
     <PackageReference Include="Xamarin.FFImageLoading.Transformations">
       <Version>2.4.11.982</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2337" />
     <PackageReference Include="Xamarin.Android.Support.ViewPager" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Android.Support.Design" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="28.0.0.3" />
@@ -120,7 +119,7 @@
       <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="Rg.Plugins.Popup">
-      <Version>2.0.0.3</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt">
       <Version>6.17.0</Version>

--- a/Xamarin/SSW.Rewards/SSW.Rewards.Android/SSW.Rewards.Android.csproj
+++ b/Xamarin/SSW.Rewards/SSW.Rewards.Android/SSW.Rewards.Android.csproj
@@ -75,7 +75,7 @@
       <Version>4.7.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Identity.Client">
-      <Version>4.17.0</Version>
+      <Version>4.43.0</Version>
     </PackageReference>
     <PackageReference Include="Plugin.CurrentActivity">
       <Version>2.1.0.4</Version>
@@ -102,7 +102,7 @@
     <PackageReference Include="Xamarin.Android.Support.Core.Utils" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Android.Support.CustomTabs" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.AndroidX.MediaRouter" Version="1.1.0.1" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.7.2" />
     <PackageReference Include="Autofac">
       <Version>5.2.0</Version>
     </PackageReference>
@@ -122,7 +122,7 @@
       <Version>2.0.0.3</Version>
     </PackageReference>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt">
-      <Version>6.7.1</Version>
+      <Version>6.17.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AppCenter.Analytics">
       <Version>3.4.0</Version>

--- a/Xamarin/SSW.Rewards/SSW.Rewards.Android/SSW.Rewards.Android.csproj
+++ b/Xamarin/SSW.Rewards/SSW.Rewards.Android/SSW.Rewards.Android.csproj
@@ -38,6 +38,7 @@
     <BundleAssemblies>false</BundleAssemblies>
     <AndroidSupportedAbis>armeabi-v7a;x86;x86_64;arm64-v8a</AndroidSupportedAbis>
     <MandroidI18n />
+    <AndroidLinkMode>None</AndroidLinkMode>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -56,7 +57,7 @@
     <DefineConstants>DEBUG;</DefineConstants>
     <DebugType>portable</DebugType>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <MandroidI18n />

--- a/Xamarin/SSW.Rewards/SSW.Rewards.iOS/SSW.Rewards.iOS.csproj
+++ b/Xamarin/SSW.Rewards/SSW.Rewards.iOS/SSW.Rewards.iOS.csproj
@@ -81,7 +81,7 @@
     </Nullable>
     <OnDemandResourcesInitialInstallTags>
     </OnDemandResourcesInitialInstallTags>
-    <CodesignProvision>SSW Mobile App MG Dev Profile</CodesignProvision>
+    <CodesignProvision>Anna's iPhone Dev Profile</CodesignProvision>
     <MtouchLink>SdkOnly</MtouchLink>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'QA|iPhoneSimulator'">
@@ -1499,7 +1499,7 @@
     <PackageReference Include="Xamarin.FFImageLoading.Transformations">
       <Version>2.4.11.982</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2337" />
     <PackageReference Include="Xamarin.Essentials" Version="1.7.2" />
     <PackageReference Include="Autofac">
       <Version>5.2.0</Version>
@@ -1517,7 +1517,7 @@
       <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="Rg.Plugins.Popup">
-      <Version>2.0.0.3</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt">
       <Version>6.17.0</Version>

--- a/Xamarin/SSW.Rewards/SSW.Rewards.iOS/SSW.Rewards.iOS.csproj
+++ b/Xamarin/SSW.Rewards/SSW.Rewards.iOS/SSW.Rewards.iOS.csproj
@@ -60,7 +60,7 @@
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
     <DeviceSpecificBuild>true</DeviceSpecificBuild>
-    <CodesignProvision>SSW Mobile App MG Dev Profile</CodesignProvision>
+    <CodesignProvision>Anna's iPhone Dev Profile</CodesignProvision>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>none</DebugType>
@@ -82,6 +82,7 @@
     <OnDemandResourcesInitialInstallTags>
     </OnDemandResourcesInitialInstallTags>
     <CodesignProvision>SSW Mobile App MG Dev Profile</CodesignProvision>
+    <MtouchLink>SdkOnly</MtouchLink>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'QA|iPhoneSimulator'">
     <DebugSymbols>true</DebugSymbols>
@@ -120,6 +121,7 @@
     </OnDemandResourcesInitialInstallTags>
     <OnDemandResourcesPrefetchOrder>
     </OnDemandResourcesPrefetchOrder>
+    <MtouchLink>SdkOnly</MtouchLink>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Effects\iOSTooltipEffect.cs" />
@@ -1486,7 +1488,7 @@
       <Version>4.7.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Identity.Client">
-      <Version>4.17.0</Version>
+      <Version>4.43.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.FFImageLoading">
       <Version>2.4.11.982</Version>
@@ -1498,7 +1500,7 @@
       <Version>2.4.11.982</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.7.2" />
     <PackageReference Include="Autofac">
       <Version>5.2.0</Version>
     </PackageReference>
@@ -1518,7 +1520,7 @@
       <Version>2.0.0.3</Version>
     </PackageReference>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt">
-      <Version>6.7.1</Version>
+      <Version>6.17.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AppCenter.Analytics">
       <Version>3.4.0</Version>

--- a/Xamarin/SSW.Rewards/SSW.Rewards/Constants.cs
+++ b/Xamarin/SSW.Rewards/SSW.Rewards/Constants.cs
@@ -7,7 +7,7 @@ namespace SSW.Rewards
         private string authorityBase { get { return $"https://{AADDB2CTenantName}.b2clogin.com/tfp/{AADB2CTenantId}/"; } }
 
 #if DEBUG
-        public string ApiBaseUrl = "https://147c-159-196-124-207.ngrok.io";//"https://sswconsulting-dev.azurewebsites.net";
+        public string ApiBaseUrl = "https://sswconsulting-dev.azurewebsites.net";//"https://147c-159-196-124-207.ngrok.io";
         public string AppCenterAndroidId = "bfe53aa1-a7df-499d-900f-725a5222fc23";
 
 #elif QA

--- a/Xamarin/SSW.Rewards/SSW.Rewards/SSW.Rewards.csproj
+++ b/Xamarin/SSW.Rewards/SSW.Rewards/SSW.Rewards.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Configurations>Debug;Release;QA</Configurations>
+    <Configurations>Debug;QA;Release</Configurations>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.17.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.43.0" />
     <PackageReference Include="Mobile.BuildTools" Version="1.4.0.638">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -26,7 +26,7 @@
     <PackageReference Include="Xamarin.FFImageLoading.Forms" Version="2.4.11.982" />
     <PackageReference Include="Xamarin.FFImageLoading.Transformations" Version="2.4.11.982" />
     <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />  
-    <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.7.2" />
     <PackageReference Include="Autofac" Version="5.2.0" />
     <PackageReference Include="CardsView" Version="2.6.3" />
     <PackageReference Include="SkiaSharp.Views.Forms" Version="2.80.1" />
@@ -34,7 +34,7 @@
     <PackageReference Include="ZXing.Net.Mobile" Version="2.4.1" />
     <PackageReference Include="Rg.Plugins.Popup" Version="2.0.0.3" />
     <PackageReference Include="ZXing.Net.Mobile.Forms" Version="2.4.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.7.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.17.0" />
     <PackageReference Include="Microsoft.AppCenter.Crashes" Version="3.4.0" />
     <PackageReference Include="Microsoft.AppCenter.Analytics" Version="3.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/Xamarin/SSW.Rewards/SSW.Rewards/SSW.Rewards.csproj
+++ b/Xamarin/SSW.Rewards/SSW.Rewards/SSW.Rewards.csproj
@@ -25,14 +25,14 @@
     <PackageReference Include="Xamarin.FFImageLoading" Version="2.4.11.982" />
     <PackageReference Include="Xamarin.FFImageLoading.Forms" Version="2.4.11.982" />
     <PackageReference Include="Xamarin.FFImageLoading.Transformations" Version="2.4.11.982" />
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />  
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2337" />  
     <PackageReference Include="Xamarin.Essentials" Version="1.7.2" />
     <PackageReference Include="Autofac" Version="5.2.0" />
     <PackageReference Include="CardsView" Version="2.6.3" />
     <PackageReference Include="SkiaSharp.Views.Forms" Version="2.80.1" />
     <PackageReference Include="Xamarin.Forms.Skeleton" Version="2.0.0" />
     <PackageReference Include="ZXing.Net.Mobile" Version="2.4.1" />
-    <PackageReference Include="Rg.Plugins.Popup" Version="2.0.0.3" />
+    <PackageReference Include="Rg.Plugins.Popup" Version="2.1.0" />
     <PackageReference Include="ZXing.Net.Mobile.Forms" Version="2.4.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.17.0" />
     <PackageReference Include="Microsoft.AppCenter.Crashes" Version="3.4.0" />


### PR DESCRIPTION
- Updated some packages, note `Microsoft.Identity.Client`
- Upgraded `Xamarin.Forms` from 4.8 to 5 for MSAL packages to work correctly.
- Upgraded `Rg.Plugins.Popup` from 2.0 to 2.1 for popups to work correctly in iOS. 
- Revert ApiBaseUrl from local ngrok to https://sswconsulting-dev.azurewebsites.net