### PR TITLE
Bump app version and add release notes for iOS

### DIFF
--- a/.github/workflows/xamarin.yml
+++ b/.github/workflows/xamarin.yml
@@ -137,4 +137,5 @@ jobs:
             --store "App Store Connect Users" \
             -f bin/iPhone/Release/SSW.Consulting.iOS.ipa \
             -a SSW.MobileApps/SSW.Xamarin.iOS \
+            --release-notes release.txt \
             --token ${{secrets.APP_CENTER_KEY}}

--- a/Xamarin/SSW.Rewards/SSW.Rewards.Android/Properties/AndroidManifest.xml
+++ b/Xamarin/SSW.Rewards/SSW.Rewards.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.78" package="com.ssw.consulting" android:installLocation="auto" android:versionCode="17">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.79" package="com.ssw.consulting" android:installLocation="auto" android:versionCode="18">
 	<uses-sdk android:minSdkVersion="24" android:targetSdkVersion="30" />
 	<application android:label="SSW Rewards" android:icon="@mipmap/launcher_foreground" android:roundIcon="@mipmap/ic_launcher_round">
 		<activity android:name="microsoft.identity.client.BrowserTabActivity" android:exported="true">

--- a/Xamarin/SSW.Rewards/SSW.Rewards.Android/Properties/AndroidManifest.xml
+++ b/Xamarin/SSW.Rewards/SSW.Rewards.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.79" package="com.ssw.consulting" android:installLocation="auto" android:versionCode="18">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.78" package="com.ssw.consulting" android:installLocation="auto" android:versionCode="18">
 	<uses-sdk android:minSdkVersion="24" android:targetSdkVersion="30" />
 	<application android:label="SSW Rewards" android:icon="@mipmap/launcher_foreground" android:roundIcon="@mipmap/ic_launcher_round">
 		<activity android:name="microsoft.identity.client.BrowserTabActivity" android:exported="true">

--- a/Xamarin/SSW.Rewards/SSW.Rewards.iOS/Info.plist
+++ b/Xamarin/SSW.Rewards/SSW.Rewards.iOS/Info.plist
@@ -55,7 +55,7 @@
 		</dict>
 	</array>
 	<key>CFBundleShortVersionString</key>
-	<string>1.78</string>
+	<string>1.79</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>NSCalendarsUsageDescription</key>

--- a/Xamarin/SSW.Rewards/SSW.Rewards.iOS/Info.plist
+++ b/Xamarin/SSW.Rewards/SSW.Rewards.iOS/Info.plist
@@ -55,9 +55,9 @@
 		</dict>
 	</array>
 	<key>CFBundleShortVersionString</key>
-	<string>1.79</string>
+	<string>1.78</string>
 	<key>CFBundleVersion</key>
-	<string>1.0</string>
+	<string>1.1</string>
 	<key>NSCalendarsUsageDescription</key>
 	<string>This permission will enable you to save SSW User Groups and other events</string>
 	<key>NSPhotoLibraryUsageDescription</key>


### PR DESCRIPTION
Bumping app versions for both Android and iOS as releases won't build for duplicated version number.

Add iOS release notes to fix build error in:
https://github.com/SSWConsulting/SSW.Rewards/runs/5981256844?check_suite_focus=true
_*apparently the log can't be found now, but it did indicate missing iOS release notes._