### PR TITLE
Auto increment app build versions for both iOS and Android

### DIFF
--- a/.github/workflows/xamarin.yml
+++ b/.github/workflows/xamarin.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v1
+      with:
+        fetch-depth: 0
 
     - name: Install dependencies
       run: nuget restore Xamarin/SSW.Rewards.sln
@@ -27,6 +29,17 @@ jobs:
       run: |
         keystore=$RUNNER_TEMP/key.keystore
         echo -n "$ANDROID_SIGNING_KEY_BASE64" | base64 --decode --output $keystore
+
+    - name: Extract version from tag
+      uses: damienaicheh/extract-version-from-tag-action@v1.0.0
+
+    - name: Update AndroidManifest.xml
+      uses: damienaicheh/update-android-version-manifest-action@v1.0.0
+      with:
+        android-manifest-path: 'Xamarin/SSW.Rewards/SSW.Rewards.Android/Properties/AndroidManifest.xml'
+        version-code: ${{ env.NUMBER_OF_COMMITS }}
+        version-name: '${{ env.MAJOR }}.${{ env.MINOR }}'
+        print-file: true
 
     - name: Build
       env:
@@ -47,6 +60,8 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v1
+      with:
+        fetch-depth: 0
 
     - name: Install dependencies
       run: nuget restore Xamarin/SSW.Rewards.sln
@@ -80,6 +95,16 @@ jobs:
         mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
         cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
 
+    - name: Extract version from tag
+      uses: damienaicheh/extract-version-from-tag-action@v1.0.0
+
+    - name: Update Info.plist
+      uses: damienaicheh/update-ios-version-info-plist-action@v1.0.0
+      with:
+        info-plist-path: 'Xamarin/SSW.Rewards/SSW.Rewards.iOS/Info.plist'
+        bundle-short-version-string: '${{ env.MAJOR }}.${{ env.MINOR }}'
+        bundle-version: '1.${{ env.NUMBER_OF_COMMITS }}'
+        print-file: true
 
     - name: Build
       run: |

--- a/.github/workflows/xamarin.yml
+++ b/.github/workflows/xamarin.yml
@@ -16,7 +16,7 @@ jobs:
   Android:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         fetch-depth: 0
 
@@ -59,7 +59,7 @@ jobs:
   iOS:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
This PR handles auto incrementation of app build versions for both iOS and Android.

## IMPORTANT:
Build version name will be based on `release tag` on branch. Build version number will be based on `count of commits` under the release tag.

Action `damienaicheh/extract-version-from-tag-action@v1.0.0` accepts only tags in the format of `x.x.x` or `vx.x.x` and currently spits out string in the format of `x.x` to be assigned to iOS and Android version names, just to be consistent with the previous build version name formatting.

## Example: 
Release tag `1.78.0` and has `2 commits` associated with the tag upon merge into staging.

__iOS__
Bundle versions string(short) = 1.78
Bundle version = 1.2 (1.x)

__Android__
Version name = 1.78
Version number = 2