### PR TITLE
Fix DeleteInstallation endpoint and temp auth workaround for testing Push Notifications in Dev 

### DIFF
--- a/API/SSW.Rewards.Application/Notifications/Commands/DeleteInstallation/DeleteInstallationCommand.cs
+++ b/API/SSW.Rewards.Application/Notifications/Commands/DeleteInstallation/DeleteInstallationCommand.cs
@@ -9,6 +9,11 @@ namespace SSW.Rewards.Application.Notifications.Commands.DeleteInstallation
     public class DeleteInstallationCommand : IRequest<Unit>
     {
         public string InstallationId { get; set; }
+
+        public DeleteInstallationCommand(string installationId)
+        {
+            InstallationId = installationId;
+        }
         
         public sealed class DeleteInstallationCommandHandler : IRequestHandler<DeleteInstallationCommand, Unit>
         {

--- a/API/SSW.Rewards.Application/Notifications/Commands/RequestNotification/RequestNotificationCommand.cs
+++ b/API/SSW.Rewards.Application/Notifications/Commands/RequestNotification/RequestNotificationCommand.cs
@@ -8,6 +8,7 @@ using SSW.Rewards.Application.Common.Models;
 
 namespace SSW.Rewards.Application.Notifications.Commands.RequestNotification
 {
+    //TODO: Pending V2 admin portal
     public class RequestNotificationCommand : IRequest<Unit>
     {
         public string Text { get; set; }

--- a/API/SSW.Rewards.Application/Notifications/Commands/RequestNotification/RequestNotificationCommand.cs
+++ b/API/SSW.Rewards.Application/Notifications/Commands/RequestNotification/RequestNotificationCommand.cs
@@ -52,15 +52,15 @@ namespace SSW.Rewards.Application.Notifications.Commands.RequestNotification
                 if (!success)
                     throw new Exception("Request Failed");
               
-                var notificationEntry = new Domain.Entities.Notifications
-                {
-                    Message = notification.Text,
-                    NotificationTag = string.Join(",", notification.Tags),
-                    NotificationAction = notification.Action,
-                    SentByStaffMember = _currentUserService.GetUserEmail() 
-                };                
-                await _context.Notifications.AddAsync(notificationEntry, cancellationToken);
-                await _context.SaveChangesAsync(cancellationToken);
+                //var notificationEntry = new Domain.Entities.Notifications
+                //{
+                //    Message = notification.Text,
+                //    NotificationTag = string.Join(",", notification.Tags),
+                //    NotificationAction = notification.Action
+                //    SentByStaffMember = _currentUserService.GetUserEmail()
+                //};                
+                //await _context.Notifications.AddAsync(notificationEntry, cancellationToken);
+                //await _context.SaveChangesAsync(cancellationToken);
                 
                 return Unit.Value;
             }

--- a/API/SSW.Rewards/Controllers/NotificationsController.cs
+++ b/API/SSW.Rewards/Controllers/NotificationsController.cs
@@ -7,9 +7,11 @@ using SSW.Rewards.Application.Notifications.Commands.DeleteInstallation;
 using SSW.Rewards.Application.Notifications.Commands.RequestNotification;
 using SSW.Rewards.Application.Notifications.Commands.UpdateInstallation;
 using SSW.Rewards.Application.Notifications.Queries.GetNotificationHistoryList;
+using Microsoft.AspNetCore.Authorization;
 
 namespace SSW.Rewards.WebAPI.Controllers
 {
+    [AllowAnonymous]
     public class NotificationsController : BaseController
     {
         [HttpGet]
@@ -37,9 +39,9 @@ namespace SSW.Rewards.WebAPI.Controllers
         [HttpDelete("{installationId}")]
         [ProducesResponseType((int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-        public async Task<ActionResult<Unit>> DeleteInstallation([Required][FromRoute]DeleteInstallationCommand installationId)
+        public async Task<ActionResult<Unit>> DeleteInstallation([Required][FromRoute]string installationId)
         {
-            return Ok(await Mediator.Send(installationId));
+            return Ok(await Mediator.Send(new DeleteInstallationCommand(installationId)));
         }
     }
 }

--- a/API/SSW.Rewards/Controllers/NotificationsController.cs
+++ b/API/SSW.Rewards/Controllers/NotificationsController.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Authorization;
 
 namespace SSW.Rewards.WebAPI.Controllers
 {
+    //TODO: Pending V2 admin portal
     [AllowAnonymous]
     public class NotificationsController : BaseController
     {

--- a/API/SSW.Rewards/nswag/SSW-Rewards-client.ts
+++ b/API/SSW.Rewards/nswag/SSW-Rewards-client.ts
@@ -602,7 +602,7 @@ export class NotificationsClient extends BaseClient implements INotificationsCli
         let url_ = this.baseUrl + "/api/Notifications/DeleteInstallation/{installationId}";
         if (installationId === undefined || installationId === null)
             throw new Error("The parameter 'installationId' must be defined.");
-        url_ = url_.replace("{InstallationId}", encodeURIComponent("" + installationId));
+        url_ = url_.replace("{installationId}", encodeURIComponent("" + installationId));
         url_ = url_.replace(/[?&]$/, "");
 
         let options_ = <RequestInit>{

--- a/API/SSW.Rewards/wwwroot/api/specification.json
+++ b/API/SSW.Rewards/wwwroot/api/specification.json
@@ -381,7 +381,7 @@
         "operationId": "Notifications_DeleteInstallation",
         "parameters": [
           {
-            "name": "InstallationId",
+            "name": "installationId",
             "in": "path",
             "required": true,
             "schema": {

--- a/Xamarin/SSW.Rewards/SSW.Rewards/Helpers/ApiClient.g.cs
+++ b/Xamarin/SSW.Rewards/SSW.Rewards/Helpers/ApiClient.g.cs
@@ -1424,7 +1424,7 @@ namespace SSW.Rewards
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/api/Notifications/DeleteInstallation/{installationId}");
-            urlBuilder_.Replace("{InstallationId}", System.Uri.EscapeDataString(ConvertToString(installationId, System.Globalization.CultureInfo.InvariantCulture)));
+            urlBuilder_.Replace("{installationId}", System.Uri.EscapeDataString(ConvertToString(installationId, System.Globalization.CultureInfo.InvariantCulture)));
     
             var client_ = _httpClient;
             var disposeClient_ = false;


### PR DESCRIPTION
Need this PR to be merged so that auth is temporarily gone for only Push Notifications endpoints, allowing me to test to see app is working with Push Notifications in the dev environment.

Things I have done specifically in this PR are:
- Commented out the db stuff inside `RequestNotificationCommand` as currently missing Notification table
- Fixed error 500 upon calling `/api/Notifications/DeleteInstallation/{installationId}` API endpoint
- Added [AllowAnonymous] to `NotificationsController` to bypass auth for test.