### PR TITLE
Revert "Bump Microsoft.AspNetCore.Authentication.JwtBearer from 3.0.0 to 3.1.18 in /API/SSW.Rewards"

### DIFF
--- a/API/SSW.Rewards/SSW.Rewards.WebAPI.csproj
+++ b/API/SSW.Rewards/SSW.Rewards.WebAPI.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.3.6" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="8.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.0.0" />
     <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="4.1.0" />
 <!--    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.8" />-->


### PR DESCRIPTION
Reverts SSWConsulting/SSW.Rewards#220
Suggested version is incompatible. This will be resolved when we upgrade the API to .NET 6.